### PR TITLE
Use container's system CA trust store

### DIFF
--- a/bin/rally-verify-wrapper.sh
+++ b/bin/rally-verify-wrapper.sh
@@ -78,7 +78,16 @@ else
 fi
 set -x
 
-unset OS_CACERT
+if [[ -z "$(sudo ls -A /usr/local/share/ca-certificates)" ]]; then
+    # Assume that any CA certificate referenced in the openrc file will not be
+    # valid within the container.
+    unset OS_CACERT
+else
+    # Use the container's system CA trust store. This allows for bind mounting a CA
+    # certificate under /usr/local/share/ca-certificates/.
+    sudo update-ca-certificates
+    export OS_CACERT=/etc/ssl/certs/ca-certificates.crt
+fi
 
 crudini --set ~/.rally/rally.conf DEFAULT openstack_client_http_timeout 300
 crudini --set ~/.rally/rally.conf openstack flavor_ref_ram 128


### PR DESCRIPTION
Previously it was not possible to use this image in an environment with
a CA that is not trusted by the Python trust store. This is because the
rally-verify-wrapper.sh script unset any OS_CACERT environment variable
(presumably assuming any CA cert would not necessarily be available in
the container).

This change makes it possible to bind mount CA certificates in the
container under /usr/local/share/ca-certificates/ and have them added
to the system trust store and used by Rally/Tempest. In this case,
OS_CACERT is set automatically.

If there are no certificates in /usr/local/share/ca-certificates/, we
revert to the previous behaviour of unsetting OS_CACERT.
