### PR TITLE
Raise Tempest flavor memory

### DIFF
--- a/bin/rally-verify-wrapper.sh
+++ b/bin/rally-verify-wrapper.sh
@@ -90,8 +90,8 @@ else
 fi
 
 crudini --set ~/.rally/rally.conf DEFAULT openstack_client_http_timeout 300
-crudini --set ~/.rally/rally.conf openstack flavor_ref_ram 128
-crudini --set ~/.rally/rally.conf openstack flavor_ref_alt_ram 256
+crudini --set ~/.rally/rally.conf openstack flavor_ref_ram 320
+crudini --set ~/.rally/rally.conf openstack flavor_ref_alt_ram 384
 crudini --set ~/.rally/rally.conf openstack flavor_ref_disk 1
 crudini --set ~/.rally/rally.conf openstack flavor_ref_alt_disk 1
 # Use a StackHPC-built image without a default password.


### PR DESCRIPTION
Align with Kolla-Ansible CI values to allow aarch64 CirrOS guests to boot through UEFI.